### PR TITLE
[fix]オーバーレイのクローズ処理を変更

### DIFF
--- a/web/frontend/src/components/Login.vue
+++ b/web/frontend/src/components/Login.vue
@@ -34,10 +34,8 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="orange" text @click="closeByEmit">キャンセル</v-btn>
-        <v-btn type="submit" color="orange" dark @click="closeByEmit"
-          >ログイン</v-btn
-        >
+        <v-btn color="orange" text @click="close">キャンセル</v-btn>
+        <v-btn type="submit" color="orange" dark>ログイン</v-btn>
       </v-card-actions>
     </form>
     <form v-show="tab === 2" @submit.prevent="register">
@@ -99,10 +97,8 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="orange" text @click="closeByEmit">キャンセル</v-btn>
-        <v-btn type="submit" color="orange" dark @click="closeByEmit"
-          >登録</v-btn
-        >
+        <v-btn color="orange" text @click="close">キャンセル</v-btn>
+        <v-btn type="submit" color="orange" dark>登録</v-btn>
       </v-card-actions>
     </form>
   </v-card>
@@ -130,8 +126,8 @@ export default {
     };
   },
   methods: {
-    closeByEmit() {
-      this.$emit("close-click", (this.dialog = false));
+    close() {
+      this.$store.dispatch("auth/close");
     },
     async login() {
       // authストアのloginアクションの呼び出し

--- a/web/frontend/src/components/Navbar.vue
+++ b/web/frontend/src/components/Navbar.vue
@@ -45,11 +45,11 @@
       <div class="my-2" v-else>
         <v-dialog v-model="dialog" persistent max-width="600px">
           <template v-slot:activator="{ on, attrs }">
-            <v-btn outlined large v-on="on" v-bind="attrs"
+            <v-btn outlined large v-on="on" v-bind="attrs" @click="open"
               >登録／ログイン</v-btn
             >
           </template>
-          <Login :dialog="dialog" @close-click="emitEvent" />
+          <Login />
         </v-dialog>
       </div>
     </v-app-bar>
@@ -63,12 +63,9 @@ export default {
   components: {
     Login
   },
-  data: () => ({
-    dialog: false
-  }),
   methods: {
-    emitEvent(child_dialog) {
-      this.dialog = child_dialog;
+    open() {
+      this.$store.dispatch("auth/open");
     },
 
     async logout() {
@@ -81,6 +78,9 @@ export default {
     },
     username() {
       return this.$store.getters["auth/username"];
+    },
+    dialog() {
+      return this.$store.getters["auth/display"];
     }
   }
 };

--- a/web/frontend/src/store/auth.js
+++ b/web/frontend/src/store/auth.js
@@ -2,20 +2,25 @@ import { OK } from "../util";
 
 const state = {
   user: null,
-  apiStatus: null
+  apiStatus: null,
+  display: false
 };
 
 const getters = {
   check: state => !!state.user,
-  username: state => (state.user ? state.user.name : "")
+  username: state => (state.user ? state.user.name : ""),
+  display: state => !!state.display
 };
 
 const mutations = {
   setUser(state, user) {
     state.user = user;
   },
-  setApiStatus(state, status) {
+  setpiStatus(state, status) {
     state.apiStatus = status;
+  },
+  reverseDisplay(state, property) {
+    state.display = property;
   }
 };
 
@@ -23,6 +28,7 @@ const actions = {
   async register(context, data) {
     const response = await window.axios.post("/api/register", data);
     context.commit("setUser", response.data);
+    context.commit("reverseDisplay", false);
   },
 
   async login(context, data) {
@@ -34,6 +40,7 @@ const actions = {
     if (response.status === OK) {
       context.commit("setApiStatus", true);
       context.commit("setUser", response.data);
+      context.commit("reverseDisplay", false);
       return false;
     }
 
@@ -44,12 +51,21 @@ const actions = {
   async logout(context) {
     await window.axios.post("/api/logout");
     context.commit("setUser", null);
+    context.commit("reverseDisplay", false);
   },
 
   async currentUser(context) {
     const response = await window.axios.get("/api/user");
     const user = response.data || null;
     context.commit("setUser", user);
+  },
+
+  open(context) {
+    context.commit("reverseDisplay", true);
+  },
+
+  close(context) {
+    context.commit("reverseDisplay", false);
   }
 };
 


### PR DESCRIPTION
# ログイン・登録処理が正常実行されたときのみオーバーレイをクローズ

## 📝 Overview

-ログイン・登録処理の成否によらず、オーバーレイがクローズされてしまうため修正

## 🔄 変更点

- $emit, propによる開閉からストアによる開閉に変更

## 🆓 その他

close #60 
