### PR TITLE
[fix]システムエラーが発生した際、登録／ログイン画面を閉じる

### DIFF
--- a/web/frontend/src/store/auth.js
+++ b/web/frontend/src/store/auth.js
@@ -1,4 +1,9 @@
-import { OK, CREATED, UNPROCESSABLE_ENTITY } from "../util";
+import {
+  OK,
+  CREATED,
+  INTERNAL_SERVER_ERROR,
+  UNPROCESSABLE_ENTITY
+} from "../util";
 
 const state = {
   user: null,
@@ -48,6 +53,9 @@ const actions = {
     if (response.status === UNPROCESSABLE_ENTITY) {
       context.commit("setRegisterErrorMessages", response.data.errors);
     } else {
+      if (response.status === INTERNAL_SERVER_ERROR) {
+        context.commit("reverseDisplay", false);
+      }
       context.commit("error/setCode", response.status, { root: true });
     }
   },
@@ -67,6 +75,9 @@ const actions = {
     if (response.status === UNPROCESSABLE_ENTITY) {
       context.commit("setLoginErrorMessages", response.data.errors);
     } else {
+      if (response.status === INTERNAL_SERVER_ERROR) {
+        context.commit("reverseDisplay", false);
+      }
       context.commit("error/setCode", response.status, { root: true });
     }
   },


### PR DESCRIPTION
# システムエラーが発生しても登録／ログイン画面がCloseしない

## 📝 Overview

- 500番台のエラーが出ても登録／ログイン画面がCloseしない

## 🔄 変更点

- authストアの`actions`に登録・ログイン時にInternal Server Error`だったときの処理を追加

## 🆓 その他

close #64 
