### PR TITLE
[fix]外部キー制約の書き方の修正とファイルの順番変更

### DIFF
--- a/web/database/migrations/2020_08_30_222542_create_contexts_table.php
+++ b/web/database/migrations/2020_08_30_222542_create_contexts_table.php
@@ -15,9 +15,11 @@ class CreateContextsTable extends Migration
     {
         Schema::create('contexts', function (Blueprint $table) {
             $table->id();
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 

--- a/web/database/migrations/2020_08_30_223602_create_projects_table.php
+++ b/web/database/migrations/2020_08_30_223602_create_projects_table.php
@@ -15,9 +15,11 @@ class CreateProjectsTable extends Migration
     {
         Schema::create('projects', function (Blueprint $table) {
             $table->id();
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
             $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 

--- a/web/database/migrations/2020_08_30_225442_create_tasks_table.php
+++ b/web/database/migrations/2020_08_30_225442_create_tasks_table.php
@@ -14,20 +14,25 @@ class CreateTasksTable extends Migration
     public function up()
     {
         Schema::create('tasks', function (Blueprint $table) {
-            $table->id()->primary();
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->id();
+            $table->unsignedBigInteger('user_id');
             $table->string('name');
-            $table->foreign('project_id')->references('id')->on('projects');
-            $table->foreign('context_id')->references('id')->on('contexts');
+            $table->unsignedBigInteger('project_id');
+            $table->unsignedBigInteger('context_id');
             $table->dateTime('start_date');
             $table->dateTime('due_date');
             $table->unsignedInteger('term');
             $table->boolean('finished');
             $table->unsignedInteger('done');
             $table->time('timer');
-            $table->foreign('repeat_id')->references('id')->on('repeats');
+            $table->unsignedBigInteger('repeat_id');
             $table->unsignedInteger('priority');
             $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('project_id')->references('id')->on('projects');
+            $table->foreign('context_id')->references('id')->on('contexts');
+            $table->foreign('repeat_id')->references('id')->on('repeats');
         });
     }
 


### PR DESCRIPTION
# 外部キー制約の書き方の修正とファイルの順番変更

## 📝 Overview

- 外部キー制約の書き方の変更
- migrationファイル名の変更

## 🔄 変更点

- 外部キー制約の書き方の変更
  - `$table->unsignedBigInteger()` の追記
  - `$table->foreign()->references()->on()` の移動
- migrationファイル名の変更
  - `2020_08_30_221442_create_tasks_table.php` → `2020_08_30_225442_create_tasks_table.php`
    - 外部キー制約のあるテーブルを先にmigrationしようとしていたため

## 🆓 その他

close #82
