### PR TITLE
[fix]登録できるプロジェクト名の最大文字サイズを15文字に変更

### DIFF
--- a/web/app/Http/Requests/AddProject.php
+++ b/web/app/Http/Requests/AddProject.php
@@ -24,7 +24,7 @@ class AddProject extends FormRequest
     public function rules()
     {
         return [
-            'project' => 'required|max:100',
+            'project' => 'required|max:15',
         ];
     }
 }

--- a/web/tests/Feature/ProjectApiTest.php
+++ b/web/tests/Feature/ProjectApiTest.php
@@ -41,9 +41,9 @@ class ProjectApiTest extends TestCase
     /**
      * @test
      */
-    public function should_プロジェクト名は100文字までOK()
+    public function should_プロジェクト名は15文字までOK()
     {
-        $name = str_repeat("a", 100);
+        $name = str_repeat("a", 15);
         $response = $this->actingAs($this->user)
             ->json('POST', route('user.project', [
                 'user' => $this->user->id,
@@ -60,9 +60,9 @@ class ProjectApiTest extends TestCase
     /**
      * @test
      */
-    public function should_プロジェクト名は101文字はNG()
+    public function should_プロジェクト名は16文字はNG()
     {
-        $name = str_repeat("a", 101);
+        $name = str_repeat("a", 16);
         $response = $this->actingAs($this->user)
             ->json('POST', route('user.project', [
                 'user' => $this->user->id,


### PR DESCRIPTION
# プロジェクト名の文字数変更

## 📝 Overview

- プロジェクト名の文字数を最大100文字から15文字に変更

## 🔄 変更点

- リクエストフォームで最大文字数を100文字から15文字へ変更
- テストの文字数を100文字から15文字に、101文字から16文字へ変更
