### PR TITLE
Task/add character count test at project edit api

### DIFF
--- a/web/tests/Feature/ProjectApiTest.php
+++ b/web/tests/Feature/ProjectApiTest.php
@@ -164,6 +164,25 @@ class ProjectApiTest extends TestCase
     /**
      * @test
      */
+    public function should_プロジェクト名は31文字に変更できない()
+    {
+        $name = str_repeat("a", 31);        $target_project = Project::where('user_id', $this->user->id)
+            ->orderBy('created_at', 'desc')
+            ->first();
+        $target = $target_project->id;
+        $response = $this->actingAs($this->user)
+            ->json('PATCH',
+                route('project.update', [
+                    $this->user->id,
+                ]),
+                compact('name', 'target'));
+
+        $response->assertStatus(422);
+    }
+
+    /**
+     * @test
+     */
     public function should_プロジェクトを削除できる()
     {
         $target_project = Project::where('user_id', $this->user->id)


### PR DESCRIPTION
# プロジェクト名変更の際の文字数のテストを追加

## 📝 Overview

- プロジェクト名変更の際30文字はOKで31文字はNGであるテストを追加

## 🔄 変更点

- プロジェクト名変更の際30文字はOKのテストを作成
- プロジェクト名変更の際31文字はNGのテストを作成

## 🆓 その他

close #105 
