### PR TITLE
[fix]プロジェクト削除テストのクエリを修正

### DIFF
--- a/web/tests/Feature/ProjectApiTest.php
+++ b/web/tests/Feature/ProjectApiTest.php
@@ -192,7 +192,7 @@ class ProjectApiTest extends TestCase
         $response = $this->actingAs($this->user)
             ->json('DELETE',
                 route('project.delete', [
-                    $target_project->id,
+                    $this->user->id,
                 ]),
                 compact('target')
             );


### PR DESCRIPTION
# プロジェクト削除テストのルーティングで指定しているユーザーIDが誤っている

## 📝 Overview

- プロジェクト削除テストのルーティングで指定しているユーザーIDを修正

## 🔄 変更点

- プロジェクト削除テストのルーティングで指定しているユーザーIDを`$target_project->id`から`$this->user->id`へ

## 🆓 その他

close #109 
