### PR TITLE
[fix]サイドバーの監視データをvuexに変更

### DIFF
--- a/web/frontend/src/components/Drawer_group.vue
+++ b/web/frontend/src/components/Drawer_group.vue
@@ -8,7 +8,7 @@
         v-for="context in contexts"
         v-bind:key="context.id"
         v-bind:icon="context.icon"
-        v-bind:title="context.title"
+        v-bind:name="context.name"
         v-bind:count="context.count"
       />
     </v-list-group>
@@ -20,7 +20,7 @@
         v-for="project in projects"
         v-bind:key="project.id"
         v-bind:icon="project.icon"
-        v-bind:title="project.title"
+        v-bind:name="project.name"
         v-bind:count="project.count"
       />
     </v-list-group>
@@ -36,91 +36,93 @@ export default {
   components: {
     List
   },
+
   data() {
     return {
       contexts: [
         {
           id: 1,
-          title: "A_早朝（4:00-6:00）",
+          name: "A_早朝（4:00-6:00）",
           icon: "mdi-moon-full",
           count: 1
         },
         {
           id: 2,
-          title: "B_出勤時間帯（6:00-8:00）",
+          name: "B_出勤時間帯（6:00-8:00）",
           icon: "mdi-moon-full",
           count: 2
         },
-        { id: 3, title: "C_朝（8:00-10:00）", icon: "mdi-moon-full", count: 3 },
+        { id: 3, name: "C_朝（8:00-10:00）", icon: "mdi-moon-full", count: 3 },
         {
           id: 4,
-          title: "D_午前中（10:00-12:00）",
+          name: "D_午前中（10:00-12:00）",
           icon: "mdi-moon-full",
           count: 4
         },
         {
           id: 5,
-          title: "E_昼（12:00-14:00）",
+          name: "E_昼（12:00-14:00）",
           icon: "mdi-moon-full",
           count: 5
         },
         {
           id: 6,
-          title: "F_午後（14:00-16:00）",
+          name: "F_午後（14:00-16:00）",
           icon: "mdi-moon-full",
           count: 6
         },
         {
           id: 7,
-          title: "G_夕方（16:00-18:00）",
+          name: "G_夕方（16:00-18:00）",
           icon: "mdi-moon-full",
           count: 7
         },
         {
           id: 8,
-          title: "H_帰宅中（18:00-20:00）",
+          name: "H_帰宅中（18:00-20:00）",
           icon: "mdi-moon-full",
           count: 8
         },
         {
           id: 9,
-          title: "I_夜（20:00-22:00）",
+          name: "I_夜（20:00-22:00）",
           icon: "mdi-moon-full",
           count: 9
         },
         {
           id: 10,
-          title: "J_深夜（22:00-24:00）",
+          name: "J_深夜（22:00-24:00）",
           icon: "mdi-moon-full",
           count: 10
         },
         {
           id: 11,
-          title: "A_早朝（4:00-6:00）",
+          name: "A_早朝（4:00-6:00）",
           icon: "mdi-moon-full",
           count: 1
         },
         {
           id: 12,
-          title: "A_早朝（4:00-6:00）",
+          name: "A_早朝（4:00-6:00）",
           icon: "mdi-moon-full",
           count: 1
         },
         {
           id: 13,
-          title: "A_早朝（4:00-6:00）",
+          name: "A_早朝（4:00-6:00）",
           icon: "mdi-moon-full",
           count: 1
         }
       ],
       projects: [
-        { id: 1, title: "今　日", icon: "mdi-moon-full", count: 100 },
-        { id: 2, title: "明　日", icon: "mdi-moon-full", count: 212 },
-        { id: 3, title: "近日中", icon: "mdi-moon-full", count: 334 },
-        { id: 4, title: "いつか", icon: "mdi-moon-full", count: 101 }
+        { id: 1, name: "今　日", icon: "mdi-moon-full", count: 100 },
+        { id: 2, name: "明　日", icon: "mdi-moon-full", count: 212 },
+        { id: 3, name: "近日中", icon: "mdi-moon-full", count: 334 },
+        { id: 4, name: "いつか", icon: "mdi-moon-full", count: 101 }
       ]
     };
   },
+
   methods: {
     async fetch(target) {
       let route = "";
@@ -140,7 +142,7 @@ export default {
       response.data.data.forEach(function(item) {
         datas.push({
           id: item.id,
-          title: item.name,
+          name: item.name,
           icon: "mdi-moon-full",
           count: 0
         });
@@ -153,13 +155,16 @@ export default {
       }
     }
   },
+
   computed: {
     ...mapGetters({
       isLogin: "auth/check",
       userId: "auth/user_id",
-      storeContexts: "context/contexts"
+      storeContexts: "context/contexts",
+      storeProjects: "project/projects"
     })
   },
+
   watch: {
     $route: {
       async handler() {
@@ -168,16 +173,34 @@ export default {
       },
       immediate: true
     },
+
     storeContexts(values) {
       if (values) {
         let datas = [];
         values["data"].forEach(function(item) {
           datas.push({
             id: item.id,
-            title: item.name
+            name: item.name,
+            icon: "mdi-moon-full",
+            count: 0
           });
         });
         this.contexts = datas;
+      }
+    },
+
+    storeProjects(values) {
+      if (values) {
+        let datas = [];
+        values["data"].forEach(function(item) {
+          datas.push({
+            id: item.id,
+            name: item.name,
+            icon: "mdi-moon-full",
+            count: 0
+          });
+        });
+        this.projects = datas;
       }
     }
   }

--- a/web/frontend/src/components/Drawer_list.vue
+++ b/web/frontend/src/components/Drawer_list.vue
@@ -6,7 +6,7 @@
 
     <v-list-item-content class="l-sidebar__item--content">
       <v-list-item-title class="l-sidebar__item--left">
-        {{ title }}
+        {{ name }}
       </v-list-item-title>
       <v-list-item-subtitle class="l-sidebar__item--right">
         {{ maxfifty }}件<span v-if="isOver50">+</span>
@@ -17,7 +17,7 @@
 
 <script>
 export default {
-  props: ["icon", "title", "count"],
+  props: ["icon", "name", "count"],
   data() {
     return {
       menuIcon: "mdi-dots-vertical"


### PR DESCRIPTION
# サイドバーに表示されるプロジェクト一覧をVuexを使う形に変更

## 📝 Overview

- Vuexのプロジェクトの変更を監視
- 変更があれば、表示しているプロジェクトを変更

## 🔄 変更点

- `watch` にプロジェクトのVuexの監視を追加
- `computed` でデータを取得する `getter` を指定

## 🆓 その他

close #145
