### PR TITLE
Feature/edit project setting

### DIFF
--- a/web/app/Http/Controllers/ProjectController.php
+++ b/web/app/Http/Controllers/ProjectController.php
@@ -64,7 +64,7 @@ class ProjectController extends Controller
         $projects = Project::where('user_id', $user_id)
             ->orderBy(Project::CREATED_AT, 'asc')
             ->get();
-        return response()->json($projects, 201);
+        return response()->json(['data' => $projects], 201);
     }
 
     /**

--- a/web/frontend/src/components/Setting_project.vue
+++ b/web/frontend/src/components/Setting_project.vue
@@ -48,6 +48,7 @@
                   v-if="isPersistedItem"
                   color="orange"
                   dark
+                  @click="update"
                 >
                   変更
                 </v-btn>
@@ -155,6 +156,14 @@ export default {
     edit(item) {
       this.projectSettingForm = item;
       this.dialog = true;
+    },
+
+    async update() {
+      await this.$store.dispatch("project/update", [
+        this.userId,
+        this.projectSettingForm
+      ]);
+      this.close();
     },
 
     close() {

--- a/web/frontend/src/store/project.js
+++ b/web/frontend/src/store/project.js
@@ -35,6 +35,23 @@ const actions = {
 
     context.commit("setApiStatus", false);
     context.commit("error/setCode", response.status, { root: true });
+  },
+
+  async update(context, data) {
+    context.commit("setApiStatus", null);
+    const response = await window.axios.patch(
+      "/api/projects/" + data[0],
+      data[1]
+    );
+
+    if (response.status === CREATED) {
+      context.commit("setApiStatus", true);
+      context.commit("setProjects", response.data);
+      return false;
+    }
+
+    context.commit("setApiStatus", false);
+    context.commit("error/setCode", response.status, { root: true });
   }
 };
 


### PR DESCRIPTION
# プロジェクト編集機能を結合する

## 📝 Overview

- 編集フォームを作成
- フォームに新しいプロジェクト名を入力してOKボタンで編集APIに送信
- 返ってきた値で設定画面を更新

## 🔄 変更点

- ダイアログのボタンを追加と変更で切り替えられるように
- 変更ボタンを押すと編集APIに送信し、プロジェクト名を更新
- プロジェクト一覧が返却され、それにより設定画面が更新される

## 🆓 その他

close #148
