### PR TITLE
[fix]プロジェクト削除テストを修正

### DIFF
--- a/web/tests/Feature/ProjectApiTest.php
+++ b/web/tests/Feature/ProjectApiTest.php
@@ -257,12 +257,13 @@ class ProjectApiTest extends TestCase
             ->orderBy('created_at', 'asc')
             ->first();
         $project_id = $target_project->id;
+        $name = $target_project->name;
         $response = $this->actingAs($this->user)
             ->json('DELETE',
                 route('project.delete', [
                     $this->user->id,
                 ]),
-                compact('project_id')
+                compact(['project_id', 'name'])
             );
         $response->assertStatus(200)
             ->assertJsonMissing(['id' => $project_id]);


### PR DESCRIPTION
# プロジェクト削除のテストを通るように修正

## 📝 Overview

- プロジェクト削除テストのクエリにプロジェクト名を追加

## 🔄 変更点

- `name`にプロジェクト名を追加
- プロジェクト削除テストのクエリを`compact('project_id', 'name')`に変更

## 🆓 その他

close #159 
