### PR TITLE
[fix]コンテキスト名の編集エラーの際、フォームを閉じないように

### DIFF
--- a/web/frontend/src/components/Setting_context.vue
+++ b/web/frontend/src/components/Setting_context.vue
@@ -182,7 +182,9 @@ export default {
         this.userId,
         this.contextAddForm
       ]);
-      this.close();
+      if (this.apiStatus) {
+        this.close();
+      }
     },
 
     async remove(item) {


### PR DESCRIPTION
エラーを確認できるようにするため #154

# コンテキスト名の編集でエラーだった際にフォームを閉じないように

## 📝 Overview

- 編集メソッドでapiStatusを確認してclose制御を行うように変更

## 🔄 変更点

- contextの設定画面で、updateメソッドにif文によるapiStatusの条件分岐を追記

## 🆓 その他

close #154 
