### PR TITLE
[fix]コンテキスト名を0文字で入力できないように変更

### DIFF
--- a/web/app/Http/Requests/ContextRequest.php
+++ b/web/app/Http/Requests/ContextRequest.php
@@ -25,7 +25,7 @@ class ContextRequest extends FormRequest
     {
         return [
             'context_id' => 'integer',
-            'name' => 'string|max:30',
+            'name' => 'required|max:30',
         ];
     }
 
@@ -36,7 +36,7 @@ class ContextRequest extends FormRequest
     public function messages()
     {
         return [
-            'name.string' => 'コンテキスト名を入力してください',
+            'name.required' => 'コンテキスト名を入力してください',
             'name.max' => 'コンテキスト名は30文字以内で入力してください',
         ];
     }

--- a/web/tests/Feature/ContextApiTest.php
+++ b/web/tests/Feature/ContextApiTest.php
@@ -263,12 +263,13 @@ class ContextApiTest extends TestCase
             ->orderBy('created_at', 'asc')
             ->first();
         $context_id = $target_context->id;
+        $name = $target_context->name;
         $response = $this->actingAs($this->user)
             ->json('DELETE',
                 route('context.delete', [
                     $this->user->id,
                 ]),
-                compact('context_id')
+                compact(['context_id', 'name'])
             );
         $response->assertStatus(200)
             ->assertJsonMissing(['id' => $context_id]);


### PR DESCRIPTION
# コンテキスト名を0文字で入力すると発生するシステムエラーを解消

## 📝 Overview

- コンテキスト名のリクエストを必須項目に

## 🔄 変更点

- contextのnameをrequiredに変更
- コンテキスト削除テストにnameを追加

## 🆓 その他

close #155
