### PR TITLE
優先度第4領域を登録できるように変更

### DIFF
--- a/web/app/Http/Requests/TaskRequest.php
+++ b/web/app/Http/Requests/TaskRequest.php
@@ -33,7 +33,7 @@ class TaskRequest extends FormRequest
             'term' => 'integer|between:0,99',
             'timer' => 'integer',
             'repeat_id' => 'integer',
-            'priority' => 'integer|between:0,4',
+            'priority' => 'integer|between:0,5',
         ];
     }
 }

--- a/web/tests/Feature/TaskApiTest.php
+++ b/web/tests/Feature/TaskApiTest.php
@@ -553,7 +553,7 @@ class TaskApiTest extends TestCase
     /**
      * @test
      */
-    public function should_priorityが4は追加できる()
+    public function should_priorityが5は追加できる()
     {
         $project = Project::where('user_id', $this->user->id)
             ->orderBy(Project::CREATED_AT, 'asc')
@@ -568,7 +568,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 4;
+        $priority = 5;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -605,7 +605,7 @@ class TaskApiTest extends TestCase
     /**
      * @test
      */
-    public function should_priorityが5以上は追加できない()
+    public function should_priorityが6以上は追加できない()
     {
         $project = Project::where('user_id', $this->user->id)
             ->orderBy(Project::CREATED_AT, 'asc')
@@ -620,7 +620,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 5;
+        $priority = 6;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [


### PR DESCRIPTION
# 優先度第4領域を登録できるように変更

## 📝 Overview

- タスク登録時に優先度に第4領域を選択すると登録できなかったが、登録できるように変更

## 🔄 変更点

- テストを改修
- リクエストファイルの優先度の範囲を0から5までの間に変更

## 🆓 その他

close #189
