### PR TITLE
[fix]タスク登録リクエストのpriorityフィールドをpriority_idに変更

### DIFF
--- a/web/app/Http/Controllers/TaskController.php
+++ b/web/app/Http/Controllers/TaskController.php
@@ -33,7 +33,7 @@ class TaskController extends Controller
         $task->done = 0;        // 未完：0 完了：1
         $task->timer = 25 * 60; // 1ポモドーロ 25分 × 60秒で残り何秒か
         $task->repeat_id = $request->repeat_id;
-        $task->priority = $request->priority;
+        $task->priority_id = $request->priority_id;
         $task->save();
 
         $new_tasks = Task::where('user_id', $user_id)

--- a/web/app/Http/Requests/TaskRequest.php
+++ b/web/app/Http/Requests/TaskRequest.php
@@ -33,7 +33,7 @@ class TaskRequest extends FormRequest
             'term' => 'integer|between:0,99',
             'timer' => 'integer',
             'repeat_id' => 'integer',
-            'priority' => 'integer|between:0,5',
+            'priority_id' => 'integer|between:0,5',
         ];
     }
 }

--- a/web/app/Priority.php
+++ b/web/app/Priority.php
@@ -10,4 +10,13 @@ class Priority extends Model
     protected $visible = [
         'id', 'name',
     ];
+
+    /**
+     * リレーションシップ - tasksテーブル
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function tasks()
+    {
+        return $this->hasMany('App\Tasks');
+    }
 }

--- a/web/app/Repeat.php
+++ b/web/app/Repeat.php
@@ -10,4 +10,13 @@ class Repeat extends Model
     protected $visible = [
         'id', 'name',
     ];
+
+    /**
+     * リレーションシップ - tasksテーブル
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function tasks()
+    {
+        return $this->hasMany('App\Tasks');
+    }
 }

--- a/web/app/Task.php
+++ b/web/app/Task.php
@@ -11,15 +11,51 @@ class Task extends Model
         'id', 'name', 'user_id', 'project_id',
         'context_id', 'start_date', 'due_date',
         'term', 'finished', 'done',
-        'timer', 'repeat_id', 'priority',
+        'timer', 'repeat_id', 'priority_id',
     ];
 
     /**
-     * リレーションシップ
+     * リレーションシップ：user_id
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function owner()
     {
         return $this->belongsTo('App\User', 'user_id', 'id', 'users');
+    }
+
+    /**
+     * リレーションシップ：project_id
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function project()
+    {
+        return $this->belongsTo('App\Project', 'project_id', 'id', 'projects');
+    }
+
+    /**
+     * リレーションシップ：context_id
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function context()
+    {
+        return $this->belongsTo('App\Context', 'context_id', 'id', 'contexts');
+    }
+
+    /**
+     * リレーションシップ：repeat_id
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function repeat()
+    {
+        return $this->belongsTo('App\Repeat', 'repeat_id', 'id', 'repeats');
+    }
+
+    /**
+     * リレーションシップ：context_id
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function priority()
+    {
+        return $this->belongsTo('App\Priority', 'priority_id', 'id', 'priorities');
     }
 }

--- a/web/database/migrations/2021_01_26_205003_rename_priority_to_priority_id_on_tasks_table.php
+++ b/web/database/migrations/2021_01_26_205003_rename_priority_to_priority_id_on_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenamePriorityToPriorityIdOnTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->renameColumn('priority', 'priority_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->renameColumn('priority_id', 'priority');
+        });
+    }
+}

--- a/web/database/migrations/2021_01_26_215300_change_priority_id_unsigned_integer_to_unsigned_big_integer_on_tasks_table.php
+++ b/web/database/migrations/2021_01_26_215300_change_priority_id_unsigned_integer_to_unsigned_big_integer_on_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangePriorityIdUnsignedIntegerToUnsignedBigIntegerOnTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->unsignedBigInteger('priority_id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->unsignedInteger('priority_id')->change();
+        });
+    }
+}

--- a/web/database/migrations/2021_01_26_215702_add_foreignkey_priority_id_on_tasks_to_id_on_priority.php
+++ b/web/database/migrations/2021_01_26_215702_add_foreignkey_priority_id_on_tasks_to_id_on_priority.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignkeyPriorityIdOnTasksToIdOnPriority extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->foreign('priority_id')->references('id')->on('priorities')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign('tasks_priority_id_foreign');
+        });
+    }
+}

--- a/web/frontend/src/components/ControlTask.vue
+++ b/web/frontend/src/components/ControlTask.vue
@@ -106,7 +106,7 @@
               :items="priorities.data"
               item-text="name"
               item-value="id"
-              v-model="addForm.priority"
+              v-model="addForm.priority_id"
             />
           </v-col>
         </v-row>

--- a/web/tests/Feature/TaskApiTest.php
+++ b/web/tests/Feature/TaskApiTest.php
@@ -42,7 +42,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 3;
+        $priority_id = 3;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -56,7 +56,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(201)
@@ -72,7 +72,7 @@ class TaskApiTest extends TestCase
                 'done' => '0',
                 'timer' => (string)(25 * 60),
                 'repeat_id' => (string)$repeat_id,
-                'priority' => (string)$priority
+                'priority_id' => (string)$priority_id
             ]);
     }
 
@@ -94,7 +94,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -108,7 +108,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -132,7 +132,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -146,7 +146,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(201)
@@ -162,7 +162,7 @@ class TaskApiTest extends TestCase
                 'done' => '0',
                 'timer' => (string)(25 * 60),
                 'repeat_id' => (string)$repeat_id,
-                'priority' => (string)$priority
+                'priority_id' => (string)$priority_id
             ]);
     }
 
@@ -184,7 +184,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -198,7 +198,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -222,7 +222,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -236,7 +236,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -260,7 +260,7 @@ class TaskApiTest extends TestCase
         $due_date = '2019-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -274,7 +274,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -298,7 +298,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = -1;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -312,7 +312,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -336,7 +336,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 0;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -350,7 +350,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(201)
@@ -366,7 +366,7 @@ class TaskApiTest extends TestCase
                 'done' => '0',
                 'timer' => (string)(25 * 60),
                 'repeat_id' => (string)$repeat_id,
-                'priority' => (string)$priority
+                'priority_id' => (string)$priority_id
             ]);
     }
 
@@ -388,7 +388,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 99;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -402,7 +402,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(201)
@@ -418,7 +418,7 @@ class TaskApiTest extends TestCase
                 'done' => '0',
                 'timer' => (string)(25 * 60),
                 'repeat_id' => (string)$repeat_id,
-                'priority' => (string)$priority
+                'priority_id' => (string)$priority_id
             ]);
     }
 
@@ -440,7 +440,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 100;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -454,7 +454,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -478,7 +478,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = -1;
+        $priority_id = -1;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -492,7 +492,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);
@@ -516,7 +516,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 0;
+        $priority_id = 0;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -530,7 +530,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
             $response->assertStatus(201)
@@ -546,7 +546,7 @@ class TaskApiTest extends TestCase
                 'done' => '0',
                 'timer' => (string)(25 * 60),
                 'repeat_id' => (string)$repeat_id,
-                'priority' => (string)$priority
+                'priority_id' => (string)$priority_id
             ]);
     }
 
@@ -568,7 +568,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 5;
+        $priority_id = 5;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -582,7 +582,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
             $response->assertStatus(201)
@@ -598,7 +598,7 @@ class TaskApiTest extends TestCase
                 'done' => '0',
                 'timer' => (string)(25 * 60),
                 'repeat_id' => (string)$repeat_id,
-                'priority' => (string)$priority
+                'priority_id' => (string)$priority_id
             ]);
     }
 
@@ -620,7 +620,7 @@ class TaskApiTest extends TestCase
         $due_date = '2020-12-31';
         $term = 5;
         $repeat_id = 1;
-        $priority = 6;
+        $priority_id = 6;
         $response = $this->actingAs($this->user)
             ->json('POST',
                 route('task.store', [
@@ -634,7 +634,7 @@ class TaskApiTest extends TestCase
                     'due_date',
                     'term',
                     'repeat_id',
-                    'priority'
+                    'priority_id'
                 )
             );
         $response->assertStatus(422);


### PR DESCRIPTION
# タスク登録リクエストのpriorityフィールドをpriority_idに変更

## 📝 Overview

- タスク登録リクエストのpriorityフィールドをpriority_idに変更

## 🔄 変更点

- TaskApiTest.phpの変更
- TaskRequest.phpの変更
- TaskController.phpの変更
- ControlTask.vueの変更

## 🆓 その他

close #190
