### PR TITLE
Fix/sidebar opening and closing

### DIFF
--- a/web/frontend/src/components/Drawer.vue
+++ b/web/frontend/src/components/Drawer.vue
@@ -26,7 +26,7 @@ export default {
   props: ["drawer"],
 
   methods: {
-    handleInput (e) {
+    handleInput(e) {
       this.$emit("drawerOpenAndClose", e);
     }
   }

--- a/web/frontend/src/components/Navbar.vue
+++ b/web/frontend/src/components/Navbar.vue
@@ -1,9 +1,6 @@
 <template>
   <div>
-    <Drawar
-      v-bind:drawer="drawer"
-      @drawerOpenAndClose="drawerOpenAndClose"
-    />
+    <Drawar v-bind:drawer="drawer" @drawerOpenAndClose="drawerOpenAndClose" />
     <v-app-bar
       color="orange darken-1"
       app


### PR DESCRIPTION
# サイドバーの開閉の挙動がスマホでおかしいのを改善

## 📝 Overview

- スマホ画面でサイドバーを閉じた際、再度開くのにサイドバーボタンを2度タップする必要があった
- 1度で済むように改修

## 🔄 変更点

- `$emit`を用いてドロワーの状態を親の開く際の変数に返すように変更

## 🆓 その他

close #96 
