### PR TITLE
[update]タスクがセットされていない状態でタイマー画面に遷移できないように

### DIFF
--- a/web/frontend/src/views/Timer.vue
+++ b/web/frontend/src/views/Timer.vue
@@ -19,6 +19,13 @@ export default {
     task: {
       type: Object
     }
+  },
+
+  // タスクがセットされていなければトップへ遷移
+  created() {
+    if (this.task === undefined) {
+      this.$router.push({ path: "/" });
+    }
   }
 };
 </script>


### PR DESCRIPTION
# タイマー画面で更新したらトップページへ遷移

## 📝 Overview

- タイマー画面を表示する際にタスクがセットされていなければトップページへ遷移するように

## 🔄 変更点

- タスクがセットされているか確認
- セットされていなければトップへ遷移

## 🆓 その他

close #266 
