### PR TITLE
[update]ポモドーロ数をインクリメントする際、日付が変わっていたらデータを新規作成するように変更

### DIFF
--- a/web/app/Http/Controllers/PomodoroController.php
+++ b/web/app/Http/Controllers/PomodoroController.php
@@ -93,8 +93,15 @@ class PomodoroController extends Controller
         $item = Pomodoro::userIdEqual($user_id)
             ->dateEqual($excution_date)
             ->first();
+        if (!$item) {
+            $item = new Pomodoro();
+            $item->user_id = $user_id;
+            $item->date = $excution_date;
+            $item->count = 0;
+        }
         $item->count += 1;
         $item->save();
+
 
         // 保存したデータを取得
         $item = Pomodoro::userIdEqual($user_id)

--- a/web/tests/Feature/PomodoroApiTest.php
+++ b/web/tests/Feature/PomodoroApiTest.php
@@ -89,6 +89,26 @@ class PomodoroApiTest extends TestCase
     /**
      * @test
      */
+    public function should_ポモドーロ数をインクリメントする際、未登録の日は登録した上でポモドーロ数を返す()
+    {
+        $date = '2021-04-23 08:00:00';
+        $response = $this->actingAs($this->user)
+            ->json(
+                'PATCH',
+                route('pomodoro.increment', [
+                    'user' => $this->user->id,
+                ]),
+                compact('date')
+            );
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'data' => ['count' => '1'],
+            ]);
+    }
+
+    /**
+     * @test
+     */
     public function should_ポモドーロ数が登録されていれば参照できる()
     {
         $date = '2021-03-27 00:00:00';


### PR DESCRIPTION
# タイマー画面に遷移した日と異なる日にタイマーが終了した場合

## 📝 Overview

- 現状、実行日がタイマー画面に遷移した日となるので、遷移後日付が変わるとエラーが発生する
- 正常に処理できるよう修正を行う

## 🔄 変更点

- インクリメント時にインクリメント用のデータが取れないときは新規作成してインクリメントするように変更

## 🆓 その他

close #268
