### PR TITLE
Feature/local transition to timer

### DIFF
--- a/web/frontend/src/components/task/list/CheckboxAndPlayButton.vue
+++ b/web/frontend/src/components/task/list/CheckboxAndPlayButton.vue
@@ -49,11 +49,8 @@ export default {
 
     transition(item) {
       if (this.userId) {
-        console.log("userid");
-      } else {
-        console.log(this.userId);
-      }
         this.$store.dispatch("pomodoro/initPomodoroCount", this.userId);
+      }
       this.$store.dispatch("pomodoro/setStateTime", item.timer);
       // this.$store.dispatch("pomodoro/setStateTime", 15);
       this.$router.push({ name: "Timer", params: { task: item } });


### PR DESCRIPTION
# 非ログイン時にタイマー画面遷移を実行してエラーが出ないように変更

## 📝 Overview

- タイマー画面に遷移するときにこれまでのポモドーロ数を参照するため、非ログイン時にエラーが発生
- 非ログイン時はポモドーロカウント0でスタートし、遷移時にこれまでのポモドーロ数を参照しないように変更

## 🔄 変更点

- DBを参照してポモドーロ数を初期化する処理はログインしている場合のみに変更

## 🆓 その他

close #308
