### PR TITLE
[update]タイマーの値を更新するのはログイン時だけに変更

### DIFF
--- a/web/frontend/src/components/timer/button/PauseButton.vue
+++ b/web/frontend/src/components/timer/button/PauseButton.vue
@@ -31,10 +31,12 @@ export default {
   methods: {
     async pause() {
       this.$store.dispatch("pomodoro/pause");
-      await this.$store.dispatch("pomodoro/updateTimer", [
-        this.userId,
-        this.task
-      ]);
+      if (this.userId) {
+        await this.$store.dispatch("pomodoro/updateTimer", [
+          this.userId,
+          this.task
+        ]);
+      }
     }
   }
 };


### PR DESCRIPTION
# 非ログイン時にタイマーを一時停止できる

## 📝 Overview

- 非ログイン時にDBのタイマーを更新しないように変更

## 🔄 変更点

- userIdがなければDBのタイマーの値を更新する処理を実行しない

## 🆓 その他

close #313 
