### PR TITLE
[update]ローカル利用時、一時停止でタイマーの値を更新するように変更

### DIFF
--- a/web/frontend/src/components/timer/button/PauseButton.vue
+++ b/web/frontend/src/components/timer/button/PauseButton.vue
@@ -36,6 +36,8 @@ export default {
           this.userId,
           this.task
         ]);
+      } else {
+        this.$store.dispatch("pomodoro/localUpdateTimer", this.task);
       }
     }
   }

--- a/web/frontend/src/store/pomodoro.js
+++ b/web/frontend/src/store/pomodoro.js
@@ -258,6 +258,23 @@ const actions = {
     context.commit("error/setCode", response.status, { root: true });
   },
 
+  localUpdateTimer(context, target_task) {
+    let tasks = context.rootState.task.tasks.data;
+    tasks = tasks.map(task => {
+      if (task.id !== target_task.task_id) {
+        return task;
+      }
+      let new_task = task;
+      if (state.mode === "break") {
+        new_task.timer = FULLTIME;
+      } else {
+        new_task.timer = state.time;
+      }
+      return new_task;
+    });
+    context.commit("task/setTasks", { data: tasks });
+  },
+
   async resetTimer(context, data) {
     const userId = data[0];
     const task = data[1];


### PR DESCRIPTION
# 一時停止でタイマーの値を更新するように変更

## 📝 Overview

- 一時停止した際に、ローカルのタイマー更新関数を叩くように変更

## 🔄 変更点

- localTimerUpdate関数を作成し、ローカル利用時に一時停止でタイマーを更新できるように変更

## 🆓 その他

close #313
