### PR TITLE
Feature/local timer continue

### DIFF
--- a/web/frontend/src/components/timer/button/ContinueButton.vue
+++ b/web/frontend/src/components/timer/button/ContinueButton.vue
@@ -30,7 +30,11 @@ export default {
 
   methods: {
     start() {
-      this.$store.dispatch("pomodoro/start", [this.userId, this.task]);
+      if (this.userId) {
+        this.$store.dispatch("pomodoro/start", [this.userId, this.task]);
+      } else {
+        this.$store.dispatch("pomodoro/localStart", this.task);
+      }
     }
   }
 };


### PR DESCRIPTION
# 非ログイン時にタイマーを再開できる

## 📝 Overview

- 続けるボタンを押すと、ローカル利用時はローカルのスタート関数を実行するように変更

## 🔄 変更点

- userIdを確認してローカル利用であれば、続けるボタンを押した際に、ローカルのスタート関数を実行するように変更

## 🆓 その他

close #319 
