### PR TITLE
[update]サイドバーの表示非表示を画面サイズに応じて変更

### DIFF
--- a/web/frontend/src/components/navbar/Navbar.vue
+++ b/web/frontend/src/components/navbar/Navbar.vue
@@ -91,9 +91,15 @@ export default {
 
   data() {
     return {
-      drawer: true,
+      drawer: false,
       keywords: ""
     };
+  },
+
+  created: function() {
+    if (1264 < window.innerWidth) {
+      this.drawer = true;
+    }
   },
 
   methods: {


### PR DESCRIPTION
# PC以外の画面だとロード画面でサイドバーが表示される

## 📝 Overview

- PC以外の画面サイズの場合、ロード画面でサイドバーが表示されてしまうため、表示されないように対応する

## 🔄 変更点

- サイドバー表示・非表示の制御変数の初期値をfalseに設定
- 画面サイズに応じて、ロード後に変数をtrueに変更

## 🆓 その他

close #331 
