### PR TITLE
Feature/building rds and private host zones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,15 +257,14 @@ workflows:
   version: 2
   deploy:
     jobs:
-      # - test
+      - test
       - build_and_push_image:
-          # requires:
-          #   - test
+          requires:
+            - test
           filters:
             branches:
               only:
                 - master
-                - feature/buildingRDSAndPrivateHostZones
       - deploy_by_ecspresso:
           requires:
             - build_and_push_image
@@ -273,4 +272,3 @@ workflows:
             branches:
               only:
                 - master
-                - feature/buildingRDSAndPrivateHostZones

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,23 @@ commands:
             cd ecspresso
             ecspresso deploy --config config_$ENV_NAME.yaml
 
+  ecspresso_register:
+    steps:
+      - run:
+          name: Register task definition
+          command: |
+            ecspresso register --config config_$ENV_NAME.yaml
+
+  migrate_database:
+    steps:
+      - run:
+          name: Migrate database
+          command: |
+            ecspresso run --config config_$ENV_NAME.yaml \
+              --latest-task-definition \
+              --watch^container=php \
+              --overrides='{"containerOverrides":[{"name":"nginx", "command":["nginx", "-v"]},{"name":"php", "command":["php", "artisan", "migrate", "--force"]}]}'
+
 jobs:
   test:
     docker:
@@ -231,6 +248,8 @@ jobs:
       - upload_env_file
       - ecspresso/install
       - ecspresso_deploy
+      - ecspresso_register
+      - migrate_database
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,14 +255,15 @@ workflows:
   version: 2
   deploy:
     jobs:
-      - test
+      # - test
       - build_and_push_image:
-          requires:
-            - test
+          # requires:
+          #   - test
           filters:
             branches:
               only:
                 - master
+                - feature/buildingRDSAndPrivateHostZones
       - deploy_by_ecspresso:
           requires:
             - build_and_push_image
@@ -270,3 +271,4 @@ workflows:
             branches:
               only:
                 - master
+                - feature/buildingRDSAndPrivateHostZones

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ commands:
       - run:
           name: Register task definition
           command: |
+            cd ecspresso
             ecspresso register --config config_$ENV_NAME.yaml
 
   migrate_database:
@@ -186,6 +187,7 @@ commands:
       - run:
           name: Migrate database
           command: |
+            cd ecspresso
             ecspresso run --config config_$ENV_NAME.yaml \
               --latest-task-definition \
               --watch^container=php \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ commands:
             cd ecspresso
             ecspresso run --config config_$ENV_NAME.yaml \
               --latest-task-definition \
-              --watch^container=php \
+              --watch-container=php \
               --overrides='{"containerOverrides":[{"name":"nginx", "command":["nginx", "-v"]},{"name":"php", "command":["php", "artisan", "migrate", "--force"]}]}'
 
 jobs:

--- a/ecspresso/ecs-service-def.json
+++ b/ecspresso/ecs-service-def.json
@@ -29,7 +29,8 @@
     "awsvpcConfiguration": {
       "assignPublicIp": "DISABLED",
       "securityGroups": [
-        "{{ tfstate `data.aws_security_group.vpc.id` }}"
+        "{{ tfstate `data.aws_security_group.vpc.id` }}",
+        "{{ tfstate `data.aws_security_group.db_todoro.id` }}"
       ],
       "subnets": [
         "{{ tfstate `data.aws_subnet.private['a'].id`}}",

--- a/ecspresso/ecs-task-def.json
+++ b/ecspresso/ecs-task-def.json
@@ -69,6 +69,10 @@
         {
           "name": "APP_KEY",
           "valueFrom": "/{{ must_env `SERVICE_NAME` }}/{{ must_env `ENV_NAME` }}/{{ must_env `SERVICE_NAME` }}/APP_KEY"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "/{{ must_env `SERVICE_NAME` }}/{{ must_env `ENV_NAME` }}/{{ must_env `SERVICE_NAME` }}/DB_PASSWORD"
         }
       ],
       "volumesFrom": []

--- a/terraform/envs/prod/cicd/app_todoro/data.tf
+++ b/terraform/envs/prod/cicd/app_todoro/data.tf
@@ -1,3 +1,11 @@
+data "aws_caller_identity" "self" {}
+
+data "aws_region" "current" {}
+
+data "aws_ecs_cluster" "this" {
+  cluster_name = "${local.name_prefix}-${local.service_name}"
+}
+
 data "aws_ecs_service" "this" {
   cluster_arn  = "${local.name_prefix}-${local.service_name}"
   service_name = "${local.name_prefix}-${local.service_name}"

--- a/terraform/envs/prod/cicd/app_todoro/ecspresso.tf
+++ b/terraform/envs/prod/cicd/app_todoro/ecspresso.tf
@@ -28,6 +28,10 @@ data "aws_lb_target_group" "this" {
   name = "${local.name_prefix}-${local.service_name}"
 }
 
+data "aws_security_group" "db_todoro" {
+  name = "${local.name_prefix}-main-db-todoro"
+}
+
 data "aws_security_group" "vpc" {
   name = "${local.name_prefix}-main-vpc"
 }

--- a/terraform/envs/prod/cicd/app_todoro/iam.tf
+++ b/terraform/envs/prod/cicd/app_todoro/iam.tf
@@ -80,7 +80,9 @@ resource "aws_iam_role_policy" "ecs" {
           "Sid" : "RegisterTaskDefinition",
           "Effect" : "Allow",
           "Action" : [
-            "ecs:RegisterTaskDefinition"
+            "ecs:RegisterTaskDefinition",
+            "ecs:ListTaskDefinitions",
+            "ecs:DescribeTaskDefinition"
           ],
           "Resource" : "*"
         },
@@ -104,6 +106,34 @@ resource "aws_iam_role_policy" "ecs" {
           ],
           "Resource" : [
             data.aws_ecs_service.this.arn
+          ]
+        },
+        {
+          "Sid" : "RunAndWaitTask",
+          "Effect" : "Allow",
+          "Action" : [
+            "ecs:RunTask",
+            "ecs:DescribeTasks"
+          ],
+          "Condition" : {
+            "ArnEquals" : {
+              "ecs:cluster" : data.aws_ecs_cluster.this.arn
+            }
+          },
+          "Resource" : [
+            "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.self.id}:task-definition/${local.name_prefix}-${local.service_name}:*",
+            "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.self.id}:task/*"
+          ]
+        },
+        {
+          "Sid" : "GetLogEvents",
+          "Effect" : "Allow",
+          "Action" : [
+            "logs:GetLogEvents"
+          ],
+          "Resource" : [
+            data.aws_cloudwatch_log_group.nginx.arn,
+            data.aws_cloudwatch_log_group.php.arn
           ]
         }
       ]

--- a/terraform/envs/prod/db/todoro/.terraform.lock.hcl
+++ b/terraform/envs/prod/db/todoro/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/terraform/envs/prod/db/todoro/backend.tf
+++ b/terraform/envs/prod/db/todoro/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "todoro-tfstate"
+    key    = "todoro/prod/db/todoro_v1.0.0.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/envs/prod/db/todoro/data.tf
+++ b/terraform/envs/prod/db/todoro/data.tf
@@ -1,0 +1,13 @@
+data "aws_kms_alias" "rds" {
+  name = "alias/aws/rds"
+}
+
+data "terraform_remote_state" "network_main" {
+  backend = "s3"
+
+  config = {
+    bucket = "todoro-tfstate"
+    key    = "${local.service_name}/${local.env_name}/network/main_v1.0.0.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/envs/prod/db/todoro/db_instance.tf
+++ b/terraform/envs/prod/db/todoro/db_instance.tf
@@ -1,0 +1,78 @@
+resource "aws_db_instance" "this" {
+  // Engine options
+  engine         = "mysql"
+  engine_version = "5.7.30"
+
+  // Settings
+  identifier = "${local.service_name}-${local.env_name}-${local.service_name}"
+
+  // Credentials Settings
+  username = local.service_name
+  password = "MustChangeStrongPassword!"
+
+  // DB instance class
+  instance_class = "db.t3.micro"
+
+  // Storage
+  storage_type          = "gp2"
+  allocated_storage     = 20
+  max_allocated_storage = 0
+
+  // Availability & durability
+  multi_az = false
+
+  // Connectivity
+  db_subnet_group_name = data.terraform_remote_state.network_main.outputs.db_subnet_group_this_id
+  publicly_accessible  = false
+  vpc_security_group_ids = [
+    data.terraform_remote_state.network_main.outputs.security_group_db_todoro_id,
+  ]
+  availability_zone = "ap-northeast-1a"
+  port              = 3306
+
+  // Database authentication
+  iam_database_authentication_enabled = false
+
+  // Database options
+  name                 = local.service_name
+  parameter_group_name = aws_db_parameter_group.this.name
+  option_group_name    = aws_db_option_group.this.name
+
+  // Backup
+  backup_retention_period  = 1
+  backup_window            = "17:00-18:00"
+  copy_tags_to_snapshot    = true
+  delete_automated_backups = true
+  skip_final_snapshot      = true
+
+  // Encryption
+  storage_encrypted = true
+  kms_key_id        = data.aws_kms_alias.rds.target_key_arn
+
+  // Performance Insights (db.t3.micro, db.t3.small are not supported)
+  performance_insights_enabled = false
+  # performance_insights_kms_key_id = data.aws_kms_alias.rds.target_key_arn
+  # performance_insights_retention_period = 7
+
+  // Monitoring
+  monitoring_interval = 60
+  monitoring_role_arn = aws_iam_role.rds_monitoring_role.arn
+
+  // Log exports
+  enabled_cloudwatch_logs_exports = [
+    "error",
+    "general",
+    "slowquery"
+  ]
+
+  // Maintenance
+  auto_minor_version_upgrade = false
+  maintenance_window         = "fri:18:00-fri:19:00"
+
+  // Deletion protection
+  deletion_protection = false
+
+  tags = {
+    Name = "${local.service_name}-${local.env_name}-${local.service_name}"
+  }
+}

--- a/terraform/envs/prod/db/todoro/db_option_group.tf
+++ b/terraform/envs/prod/db/todoro/db_option_group.tf
@@ -1,0 +1,10 @@
+resource "aws_db_option_group" "this" {
+  name = "${local.service_name}-${local.env_name}-${local.service_name}"
+
+  engine_name          = "mysql"
+  major_engine_version = "5.7"
+
+  tags = {
+    Name = "${local.service_name}-${local.env_name}-${local.service_name}"
+  }
+}

--- a/terraform/envs/prod/db/todoro/db_parameter_group.tf
+++ b/terraform/envs/prod/db/todoro/db_parameter_group.tf
@@ -1,0 +1,64 @@
+resource "aws_db_parameter_group" "this" {
+  name = "${local.service_name}-${local.env_name}-${local.service_name}"
+
+  family = "mysql5.7"
+
+  parameter {
+    name  = "character_set_client"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_connection"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_database"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_filesystem"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_results"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_0900_ai_ci"
+  }
+
+  parameter {
+    name  = "general_log"
+    value = "1"
+  }
+
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+
+  parameter {
+    name  = "long_query_time"
+    value = "1.0"
+  }
+
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+
+  tags = {
+    Name = "${local.service_name}-${local.env_name}-${local.service_name}"
+  }
+}

--- a/terraform/envs/prod/db/todoro/db_parameter_group.tf
+++ b/terraform/envs/prod/db/todoro/db_parameter_group.tf
@@ -35,7 +35,7 @@ resource "aws_db_parameter_group" "this" {
 
   parameter {
     name  = "collation_server"
-    value = "utf8mb4_0900_ai_ci"
+    value = "utf8mb4_bin"
   }
 
   parameter {

--- a/terraform/envs/prod/db/todoro/iam.tf
+++ b/terraform/envs/prod/db/todoro/iam.tf
@@ -1,0 +1,27 @@
+resource "aws_iam_role" "rds_monitoring_role" {
+  name = "${local.service_name}-${local.env_name}-${local.service_name}-rds-monitoring-role"
+
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "monitoring.rds.amazonaws.com"
+          },
+          "Action" : "sts:AssumeRole"
+        }
+      ]
+    }
+  )
+}
+
+data "aws_iam_policy" "rds_enhanced_monitoring_role" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring_role" {
+  role       = aws_iam_role.rds_monitoring_role.name
+  policy_arn = data.aws_iam_policy.rds_enhanced_monitoring_role.arn
+}

--- a/terraform/envs/prod/db/todoro/outputs.tf
+++ b/terraform/envs/prod/db/todoro/outputs.tf
@@ -1,0 +1,3 @@
+output "db_instance_this_address" {
+	value = aws_db_instance.this.address
+}

--- a/terraform/envs/prod/db/todoro/provider.tf
+++ b/terraform/envs/prod/db/todoro/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/terraform/envs/prod/db/todoro/shared_locals.tf
+++ b/terraform/envs/prod/db/todoro/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf

--- a/terraform/envs/prod/log/db_todoro/.terraform.lock.hcl
+++ b/terraform/envs/prod/log/db_todoro/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/terraform/envs/prod/log/db_todoro/backend.tf
+++ b/terraform/envs/prod/log/db_todoro/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "todoro-tfstate"
+    key    = "todoro/prod/log/db_todoro_v1.0.0.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/envs/prod/log/db_todoro/cloudwatch_log.tf
+++ b/terraform/envs/prod/log/db_todoro/cloudwatch_log.tf
@@ -1,0 +1,17 @@
+resource "aws_cloudwatch_log_group" "error" {
+  name = "/aws/rds/instance/${local.name_prefix}-${local.service_name}/error"
+
+  retention_in_days = 90
+}
+
+resource "aws_cloudwatch_log_group" "general" {
+  name = "/aws/rds/instance/${local.name_prefix}-${local.service_name}/general"
+
+  retention_in_days = 90
+}
+
+resource "aws_cloudwatch_log_group" "slowquery" {
+  name = "/aws/rds/instance/${local.name_prefix}-${local.service_name}/slowquery"
+
+  retention_in_days = 90
+}

--- a/terraform/envs/prod/log/db_todoro/provider.tf
+++ b/terraform/envs/prod/log/db_todoro/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/terraform/envs/prod/log/db_todoro/shared_locals.tf
+++ b/terraform/envs/prod/log/db_todoro/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf

--- a/terraform/envs/prod/network/main/db_subnet_group.tf
+++ b/terraform/envs/prod/network/main/db_subnet_group.tf
@@ -1,0 +1,10 @@
+resource "aws_db_subnet_group" "this" {
+  name = aws_vpc.this.tags.Name
+  subnet_ids = [
+    for s in aws_subnet.private : s.id
+  ]
+
+  tags = {
+    Name = aws_vpc.this.tags.Name
+  }
+}

--- a/terraform/envs/prod/network/main/outputs.tf
+++ b/terraform/envs/prod/network/main/outputs.tf
@@ -21,3 +21,7 @@ output "subnet_private" {
 output "vpc_this_id" {
   value = aws_vpc.this.id
 }
+
+output "db_subnet_group_this_id" {
+  value = aws_db_subnet_group.this.id
+}

--- a/terraform/envs/prod/network/main/outputs.tf
+++ b/terraform/envs/prod/network/main/outputs.tf
@@ -6,6 +6,10 @@ output "security_group_vpc_id" {
   value = aws_security_group.vpc.id
 }
 
+output "security_group_db_todoro_id" {
+  value = aws_security_group.db_todoro.id
+}
+
 output "subnet_public" {
   value = aws_subnet.public
 }

--- a/terraform/envs/prod/network/main/security_group.tf
+++ b/terraform/envs/prod/network/main/security_group.tf
@@ -50,3 +50,25 @@ resource "aws_security_group" "vpc" {
     Name = "${aws_vpc.this.tags.Name}-vpc"
   }
 }
+
+resource "aws_security_group" "db_todoro" {
+  name   = "${aws_vpc.this.tags.Name}-db-todoro"
+  vpc_id = aws_vpc.this.vpc_id
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${aws_vpc.this.tags.Name}-db-todoro"
+  }
+}

--- a/terraform/envs/prod/network/main/security_group.tf
+++ b/terraform/envs/prod/network/main/security_group.tf
@@ -53,7 +53,7 @@ resource "aws_security_group" "vpc" {
 
 resource "aws_security_group" "db_todoro" {
   name   = "${aws_vpc.this.tags.Name}-db-todoro"
-  vpc_id = aws_vpc.this.vpc_id
+  vpc_id = aws_vpc.this.id
   ingress {
     from_port = 0
     to_port   = 0

--- a/terraform/envs/prod/routing/todoro_internal/.terraform.lock.hcl
+++ b/terraform/envs/prod/routing/todoro_internal/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.42.0"
+  constraints = "3.42.0"
+  hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
+    "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
+    "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",
+    "zh:40fed7637ab8ddeb93bef06aded35d970f0628025b97459ae805463e8aa0a58a",
+    "zh:68def3c0a5a1aac1db6372c51daef858b707f03052626d3427ac24cba6f2014d",
+    "zh:6db7ec9c8d1803a0b6f40a664aa892e0f8894562de83061fa7ac1bc51ff5e7e5",
+    "zh:7058abaad595930b3f97dc04e45c112b2dbf37d098372a849081f7081da2fb52",
+    "zh:8c25adb15a19da301c478aa1f4a4d8647cabdf8e5dae8331d4490f80ea718c26",
+    "zh:8e129b847401e39fcbc54817726dab877f36b7f00ff5ed76f7b43470abe99ff9",
+    "zh:d268bb267a2d6b39df7ddee8efa7c1ef7a15cf335dfa5f2e64c9dae9b623a1b8",
+    "zh:d6eeb3614a0ab50f8e9ab5666ae5754ea668ce327310e5b21b7f04a18d7611a8",
+    "zh:f5d3c58055dff6e38562b75d3edc908cb2f1e45c6914f6b00f4773359ce49324",
+  ]
+}

--- a/terraform/envs/prod/routing/todoro_internal/backend.tf
+++ b/terraform/envs/prod/routing/todoro_internal/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "todoro-tfstate"
+    key    = "todoro/prod/routing/todoro_interval_v1.0.1.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/envs/prod/routing/todoro_internal/data.tf
+++ b/terraform/envs/prod/routing/todoro_internal/data.tf
@@ -1,0 +1,19 @@
+data "terraform_remote_state" "network_main" {
+  backend = "s3"
+
+  config = {
+    bucket = "todoro-tfstate"
+    key    = "${local.service_name}/${local.env_name}/network/main_v1.0.0.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+data "terraform_remote_state" "db_todoro" {
+  backend = "s3"
+
+  config = {
+    bucket = "todoro-tfstate"
+    key    = "${local.service_name}/${local.env_name}/db/todoro_v1.0.0.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/envs/prod/routing/todoro_internal/provider.tf
+++ b/terraform/envs/prod/routing/todoro_internal/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/terraform/envs/prod/routing/todoro_internal/route53.tf
+++ b/terraform/envs/prod/routing/todoro_internal/route53.tf
@@ -1,0 +1,18 @@
+resource "aws_route53_zone" "this" {
+  name = "todoro.internal"
+
+  vpc {
+    vpc_id = data.terraform_remote_state.network_main.outputs.vpc_this_id
+  }
+}
+
+resource "aws_route53_record" "db_cname" {
+  zone_id = aws_route53_zone.this.zone_id
+  name    = "db.${aws_route53_zone.this.name}"
+  type    = "CNAME"
+  ttl     = 300
+
+  records = [
+    data.terraform_remote_state.db_todoro.outputs.db_instance_this_address
+  ]
+}

--- a/terraform/envs/prod/routing/todoro_internal/shared_locals.tf
+++ b/terraform/envs/prod/routing/todoro_internal/shared_locals.tf
@@ -1,0 +1,1 @@
+../../shared_locals.tf

--- a/web/.env.prod
+++ b/web/.env.prod
@@ -6,3 +6,10 @@ APP_URL=https://todoro.tokyo
 
 LOG_CHANNEL=stderr
 LOG_LEVEL=info
+
+DB_CONNECTION=mysql
+DB_HOST=db.todoro.internal
+DB_PORT=3306
+DB_DATABASE=todoro
+DB_USERNAME=user
+# DB_PASSWORD=parameter_store

--- a/web/.env.prod
+++ b/web/.env.prod
@@ -11,5 +11,5 @@ DB_CONNECTION=mysql
 DB_HOST=db.todoro.internal
 DB_PORT=3306
 DB_DATABASE=todoro
-DB_USERNAME=user
+DB_USERNAME=todoro
 # DB_PASSWORD=parameter_store


### PR DESCRIPTION
# RDSとプライベートホストゾーンの構築

## 📝 Overview

- RDSを構築
- ECSタスクから接続できるように設定

## 🔄 変更点

- RDS用セキュリティグループの作成
- DBサブネットグループの作成
- DBパラメータグループの作成
- DBオプショングループの作成
- CloudWatchロググループの作成
- RDS（DBインスタンス）の作成
- RDSのパスワード変更
- パラメータストアの作成
- タスク定義ファイルの編集
- ECSサービスにRDS用セキュリティグループを付与
- DBマイグレーション処理の追加
- RDS用のCNAMEレコードの作成
- .env.prodの編集

## 🆓 その他

close #375 
